### PR TITLE
Adds `maxSize` parameter to `/File/raw/{hash}` route

### DIFF
--- a/contentapi.data/File/GetFileModify.cs
+++ b/contentapi.data/File/GetFileModify.cs
@@ -3,6 +3,7 @@ namespace contentapi.data;
 public class GetFileModify
 {
     public int size { get; set; }
+    public int maxSize { get; set; }
     public bool crop { get; set; }
     public bool freeze { get; set; } = false;
 }

--- a/contentapi.sln
+++ b/contentapi.sln
@@ -1,19 +1,18 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30114.105
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35222.181
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "contentapi", "contentapi\contentapi.csproj", "{762071EA-F0B2-4B21-81D3-B89CC7750F96}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "contentapi", "contentapi\contentapi.csproj", "{762071EA-F0B2-4B21-81D3-B89CC7750F96}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "contentapi.test", "contentapi.test\contentapi.test.csproj", "{09193632-DC79-44F4-BED2-063CFF0961CD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "contentapi.test", "contentapi.test\contentapi.test.csproj", "{09193632-DC79-44F4-BED2-063CFF0961CD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "contentapi.data", "contentapi.data\contentapi.data.csproj", "{2A8B442A-3C59-4431-8F82-DAB1612D6092}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{762071EA-F0B2-4B21-81D3-B89CC7750F96}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -24,5 +23,12 @@ Global
 		{09193632-DC79-44F4-BED2-063CFF0961CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{09193632-DC79-44F4-BED2-063CFF0961CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{09193632-DC79-44F4-BED2-063CFF0961CD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A8B442A-3C59-4431-8F82-DAB1612D6092}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A8B442A-3C59-4431-8F82-DAB1612D6092}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A8B442A-3C59-4431-8F82-DAB1612D6092}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A8B442A-3C59-4431-8F82-DAB1612D6092}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/contentapi/Utilities/Image/ImageManipulator_IMagick.cs
+++ b/contentapi/Utilities/Image/ImageManipulator_IMagick.cs
@@ -137,8 +137,16 @@ public class ImageManipulator_IMagick : IImageManipulator
 
         var arglist = new List<string>() { filename + (baseInfo.MimeType == Constants.GifMime && !modify.freeze ? "" : "[0]") };
 
+        if (modify.size > 0 && modify.maxSize > 0)
+            throw new RequestException("Can't specify both size and maxSize in the same request!");
+
+        var size = modify.size > 0 ? modify.size : modify.maxSize;
+
         //Cropping can be done with the resize arg, add ^ to the end
-        var resize = $"{modify.size}x{modify.size}";
+        var resize = $"{size}x{size}";
+
+        if (modify.maxSize > 0)
+            resize += ">";
 
         if(modify.crop)
             resize += "^";
@@ -154,7 +162,7 @@ public class ImageManipulator_IMagick : IImageManipulator
         }
 
         if(modify.crop)
-            arglist.AddRange(new [] { "-background", "none", "-gravity", "center", "-extent", $"{modify.size}x{modify.size}"});
+            arglist.AddRange(new [] { "-background", "none", "-gravity", "center", "-extent", $"{size}x{size}"});
         
         if(baseInfo.MimeType == Constants.GifMime && !modify.freeze)
         {


### PR DESCRIPTION
This adds a new parameter which only applies the resize downward when the image width or height is larger than the specified `maxSize`.

This contains an implementation for both the direct and imagick image manipulators.

This also disallows `size` and `maxSize` from being used together.

https://github.com/user-attachments/assets/87fc1e50-709e-4765-a461-8b4c2ab269fe

